### PR TITLE
#1 イベント一覧 Issue1 開催日が過去のイベントを表示しない

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -24,21 +24,26 @@ CREATE TABLE event_attendance (
 );
 
 
-INSERT INTO events SET name='縦モク', start_at='2021/08/01 21:00', end_at='2021/08/01 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/02 21:00', end_at='2021/08/02 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/03 20:00', end_at='2021/08/03 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/08 21:00', end_at='2021/08/08 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/09 21:00', end_at='2021/08/09 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/10 20:00', end_at='2021/08/10 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/15 21:00', end_at='2021/08/15 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/16 21:00', end_at='2021/08/16 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/17 20:00', end_at='2021/08/17 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/22 21:00', end_at='2021/08/22 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/23 21:00', end_at='2021/08/23 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/24 20:00', end_at='2021/08/24 22:00';
-INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2021/09/22 22:00';
-INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2021/09/03 22:00';
-INSERT INTO events SET name='遊び', start_at='2021/09/06 18:00', end_at='2021/09/06 22:00';
+INSERT INTO events SET name='縦モク', start_at='2022/08/01 21:00', end_at='2022/08/01 23:00';
+INSERT INTO events SET name='横モク', start_at='2022/08/02 21:00', end_at='2022/08/02 23:00';
+INSERT INTO events SET name='スペモク', start_at='2022/08/03 20:00', end_at='2022/08/03 22:00';
+INSERT INTO events SET name='縦モク', start_at='2022/08/08 21:00', end_at='2022/08/08 23:00';
+INSERT INTO events SET name='横モク', start_at='2022/08/09 21:00', end_at='2022/08/09 23:00';
+INSERT INTO events SET name='スペモク', start_at='2022/08/10 20:00', end_at='2022/08/10 22:00';
+INSERT INTO events SET name='縦モク', start_at='2022/08/15 21:00', end_at='2022/08/15 23:00';
+INSERT INTO events SET name='横モク', start_at='2022/08/16 21:00', end_at='2022/08/16 23:00';
+INSERT INTO events SET name='スペモク', start_at='2022/08/17 20:00', end_at='2022/08/17 22:00';
+INSERT INTO events SET name='縦モク', start_at='2022/08/22 21:00', end_at='2022/08/22 23:00';
+INSERT INTO events SET name='横モク', start_at='2022/08/23 21:00', end_at='2022/08/23 23:00';
+INSERT INTO events SET name='スペモク', start_at='2022/08/24 20:00', end_at='2022/08/24 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/22 18:00', end_at='2022/09/22 22:00';
+INSERT INTO events SET name='ハッカソン', start_at='2022/09/03 10:00', end_at='2022/09/03 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/06 18:00', end_at='2022/09/06 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/09 18:00', end_at='2022/09/06 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/09 18:00', end_at='2022/09/06 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/10 18:00', end_at='2022/09/06 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/28 18:00', end_at='2022/09/06 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/26 18:00', end_at='2022/09/06 22:00';
 
 INSERT INTO event_attendance SET event_id=1;
 INSERT INTO event_attendance SET event_id=1;

--- a/src/index.php
+++ b/src/index.php
@@ -4,7 +4,8 @@ require('dbconnect.php');
 $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id');
 $events = $stmt->fetchAll();
 
-function get_day_of_week ($w) {
+function get_day_of_week($w)
+{
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
   return $day_of_week_list["$w"];
 }
@@ -53,12 +54,18 @@ function get_day_of_week ($w) {
           <h2 class="text-sm font-bold">一覧</h2>
         </div>
 
+        <!-- 各イベントボックス（一覧）見た目 -->
         <?php foreach ($events as $event) : ?>
           <?php
           $start_date = strtotime($event['start_at']);
           $end_date = strtotime($event['end_at']);
           $day_of_week = get_day_of_week(date("w", $start_date));
+          
+          if ($start_date < strtotime(date('Y-m-d H:i'))) {
+            continue;
+          }
           ?>
+          
           <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
             <div>
               <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
- #1 
```
終了条件
開催日が当日、未来のイベントのみ表示されている
```

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->
日時よりも過去のイベントが表示されていないことを確認しました。(9/7 4:00現在)

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
<img width="423" alt="スクリーンショット 2022-09-08 23 27 51" src="https://user-images.githubusercontent.com/59753159/189148737-8892ff5e-ad25-49a7-8987-19b8c514df0c.png">
<img width="982" alt="スクリーンショット 2022-09-08 23 29 34" src="https://user-images.githubusercontent.com/59753159/189149132-81edb980-02ce-46da-b799-410c9117a55f.png">


