### PR TITLE
#18 通知機能 Issue2 イベントの前日にメールで通知する 通知する先はユーザレコードの人すべて

### DIFF
--- a/src/sendMail.php
+++ b/src/sendMail.php
@@ -21,7 +21,7 @@ mb_internal_encoding('UTF-8');
 foreach($events as $event){
   foreach($users as $user){
     $to = $user['email'];
-    $subject = 'イベントの前日リマインド';
+    $subject = $event['name'] . 'の前日リマインド';
     $name = $user['name'];
     $eventName = $event['name']; 
     $startAt = $event['start_at'];

--- a/src/sendMail.php
+++ b/src/sendMail.php
@@ -8,42 +8,34 @@ $eventDate = [
   'start' => date('Y/m/d', strtotime('+1 day')) . ' 00:00',
   'end' => date('Y/m/d', strtotime('+1 day')) . ' 23:59'
 ];
-$stmt = $db -> prepare('SELECT * FROM events where start_at > ? AND start_at < ?');
+$stmt = $db -> prepare(
+  'SELECT id, name, 
+  TIME_FORMAT(start_at, "%H:%i") start_at, 
+  TIME_FORMAT(end_at, "%H:%i") end_at 
+  FROM events where start_at > ? AND start_at < ?');
 $stmt -> execute([$eventDate['start'], $eventDate['end']]);
 $events = $stmt -> fetchAll();
-var_dump($events);
 
 mb_language('ja');
 mb_internal_encoding('UTF-8');
+foreach($events as $event){
+  foreach($users as $user){
+    $to = $user['email'];
+    $subject = 'イベントの前日リマインド';
+    $name = $user['name'];
+    $eventName = $event['name']; 
+    $startAt = $event['start_at'];
+    $endAt = $event['end_at'];
+    $headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
+    $body = <<<EOT
+    {$name}さん
 
-foreach($users as $user){
-  $to = $user['email'];
-  $subject = 'イベントの前日リマインド';
-  $name = $user['name'];
-  $event = 
-  $body = <<<EOT
-  {$name}さん
-
-
-  EOT;
+    明日、{$eventName}を
+    {$startAt} ~ {$endAt}
+    に開催します。お楽しみに！
+    EOT;
+    mb_send_mail($to, $subject, $body, $headers);
+  }
 }
 
-$to = "hackathon-teamX@posse-ap.com";
-$subject = "PHPからメール送信サンプル";
-$body = "本文";
-$headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
-
-$name = "テスト";
-$date = "2021年08月01日（日） 21:00~23:00";
-$event = "縦モク";
-$body = <<<EOT
-{$name}さん
-
-${date}に${event}を開催します。
-参加／不参加の回答をお願いします。
-
-http://localhost/
-EOT;
-
-// mb_send_mail($to, $subject, $body, $headers);
 echo "メールを送信しました";

--- a/src/sendMail.php
+++ b/src/sendMail.php
@@ -1,0 +1,49 @@
+<?php
+
+require('/var/www/html/dbconnect.php');
+
+$stmt = $db -> query('SELECT * FROM users');
+$users = $stmt -> fetchAll();
+$eventDate = [
+  'start' => date('Y/m/d', strtotime('+1 day')) . ' 00:00',
+  'end' => date('Y/m/d', strtotime('+1 day')) . ' 23:59'
+];
+$stmt = $db -> prepare('SELECT * FROM events where start_at > ? AND start_at < ?');
+$stmt -> execute([$eventDate['start'], $eventDate['end']]);
+$events = $stmt -> fetchAll();
+var_dump($events);
+
+mb_language('ja');
+mb_internal_encoding('UTF-8');
+
+foreach($users as $user){
+  $to = $user['email'];
+  $subject = 'イベントの前日リマインド';
+  $name = $user['name'];
+  $event = 
+  $body = <<<EOT
+  {$name}さん
+
+
+  EOT;
+}
+
+$to = "hackathon-teamX@posse-ap.com";
+$subject = "PHPからメール送信サンプル";
+$body = "本文";
+$headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
+
+$name = "テスト";
+$date = "2021年08月01日（日） 21:00~23:00";
+$event = "縦モク";
+$body = <<<EOT
+{$name}さん
+
+${date}に${event}を開催します。
+参加／不参加の回答をお願いします。
+
+http://localhost/
+EOT;
+
+// mb_send_mail($to, $subject, $body, $headers);
+echo "メールを送信しました";


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
- https://github.com/posse-ap/posse2-hackathon-202209-team2E/issues/18
```
終了条件
バッチを実行すると処理日がイベントの前日の場合メールを送付する
メールの宛先はユーザレコードの人全て
メールにはイベント名、内容、開催日時を記載する


備考
メールのサンプル実装はしてある
バッチのスケジューリングは不要で手動実行想定

■バッチについて
ターミナルで以下コマンドで実行可能なこと
php hogehoge.php
※ファイル名は任意です
```
## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->
管理画面から翌日開催のイベントを二つ追加し、ターミナル上で php sendMail.php を実行した結果、登録されているユーザー全員にメールが二通ずつ送信されていることを確認しました(9/7現在)。
## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
管理画面から翌日開催のイベントを二つ（明日のイベント、明日のイベントその２）追加
<img width="397" alt="スクリーンショット 2022-09-07 12 40 43" src="https://user-images.githubusercontent.com/94879731/188784094-4dfa4429-8375-405d-a47e-fd0b5165968f.png">

php sendMail.php を実行
<img width="405" alt="スクリーンショット 2022-09-07 12 41 19" src="https://user-images.githubusercontent.com/94879731/188784104-f0ec95aa-3942-4653-9044-e6e2b0ffa917.png">

DBからユーザレコードの人全てを確認
<img width="935" alt="スクリーンショット 2022-09-08 23 09 16" src="https://user-images.githubusercontent.com/38104713/189144265-16f4d965-f74b-42af-9145-88317497f5a0.png">

ユーザレコードの人全てに二通ずつ送信できていることを確認
<img width="1440" alt="スクリーンショット 2022-09-07 12 44 09" src="https://user-images.githubusercontent.com/94879731/188784119-8f525cd1-128e-4152-85fa-5398000d4bf6.png">

↓メール本文
<img width="329" alt="スクリーンショット 2022-09-07 17 31 07" src="https://user-images.githubusercontent.com/94879731/188830689-2fd7fb4c-3fd4-4e80-838c-be5510a74168.png">
