### PR TITLE
#14 イベント参加管理 Issue3 参加状態により参加／不参加ボタンを活性／非活性にする

### DIFF
--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -6,17 +6,20 @@ session_start();
 if (isset($_GET['eventId'])) {
   $eventId = htmlspecialchars($_GET['eventId']);
   try {
+    // イベントのデータを取得
     $stmt = $db->prepare('SELECT events.id, events.name, events.start_at, events.end_at, events.detail, count(status = "presence" or null) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.id = ? GROUP BY events.id');
     $stmt->execute(array($eventId));
     $event = $stmt->fetch();
-    $stmt = $db->prepare('SELECT status FROM event_attendance WHERE event_id=? AND user_id=?');
+
+    // モーダルを開いたイベントについて、ログイン中のユーザーの参加ステータスを取得
+    $stmt = $db->prepare('SELECT status FROM event_attendance WHERE event_id = ? AND user_id = ?');
     $stmt->execute([$eventId, $_SESSION['user_id']]);
     $eventAttendance = $stmt->fetch();
-    
+
     $start_date = strtotime($event['start_at']);
     $end_date = strtotime($event['end_at']);
 
-    if($event['detail']){
+    if ($event['detail']) {
       $eventMessage = nl2br($event['detail']);
     } else {
       $eventMessage = date("Y年m月d日", $start_date) . '（' . get_day_of_week(date("w", $start_date)) . '） ' . date("H:i", $start_date) . '~' . date("H:i", $end_date) . 'に' . $event['name'] . 'を開催します。<br>ぜひ参加してください。';
@@ -38,15 +41,16 @@ if (isset($_GET['eventId'])) {
       'status' => $eventAttendance['status'],
       'deadline' => date("m月d日", strtotime('-3 day', $end_date)),
     ];
-    
+
     echo json_encode($array, JSON_UNESCAPED_UNICODE);
-  } catch(PDOException $e) {
+  } catch (PDOException $e) {
     echo $e->getMessage();
     exit();
   }
 }
 
-function get_day_of_week ($w) {
+function get_day_of_week($w)
+{
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
   return $day_of_week_list["$w"];
 }

--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -1,6 +1,7 @@
 <?php
 require('../dbconnect.php');
 header('Content-Type: application/json; charset=UTF-8');
+session_start();
 
 if (isset($_GET['eventId'])) {
   $eventId = htmlspecialchars($_GET['eventId']);
@@ -8,6 +9,9 @@ if (isset($_GET['eventId'])) {
     $stmt = $db->prepare('SELECT events.id, events.name, events.start_at, events.end_at, events.detail, count(status = "presence" or null) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.id = ? GROUP BY events.id');
     $stmt->execute(array($eventId));
     $event = $stmt->fetch();
+    $stmt = $db->prepare('SELECT status FROM event_attendance WHERE event_id=? AND user_id=?');
+    $stmt->execute([$eventId, $_SESSION['user_id']]);
+    $eventAttendance = $stmt->fetch();
     
     $start_date = strtotime($event['start_at']);
     $end_date = strtotime($event['end_at']);
@@ -31,7 +35,7 @@ if (isset($_GET['eventId'])) {
       'end_at' => date("H:i", $end_date),
       'total_participants' => $event['total_participants'],
       'message' => $eventMessage,
-      'status' => $status,
+      'status' => $eventAttendance['status'],
       'deadline' => date("m月d日", strtotime('-3 day', $end_date)),
     ];
     

--- a/src/api/postEventAttendance.php
+++ b/src/api/postEventAttendance.php
@@ -8,5 +8,24 @@ $eventId = $_POST['event_id'];
 $userId = $_SESSION['user_id'];
 $status = $_POST['status'];
 
-$stmt = $db->prepare("INSERT INTO event_attendance(event_id, user_id, status) VALUES (?,?,?)");
-$stmt->execute([$eventId, $userId, $status]);
+// すでに登録済みか確認
+$stmt = $db->prepare('SELECT * FROM event_attendance WHERE event_id = :event_id AND user_id = :user_id');
+$stmt->execute([
+  ':event_id' => $eventId,
+  ':user_id' => $userId
+]);
+$eventAttendance = $stmt->fetch();
+
+if ($eventAttendance) {
+  // 登録済みならUPDATE
+  $sql = 'UPDATE event_attendance SET status = :status WHERE event_id = :event_id AND user_id = :user_id';
+} else {
+  // 未登録ならINSERT
+  $sql = 'INSERT INTO event_attendance(event_id, user_id, status) VALUES (:event_id, :user_id, :status)';
+}
+$stmt = $db->prepare($sql);
+$stmt->execute([
+  ':event_id' => $eventId,
+  ':user_id' => $userId,
+  ':status' => $status
+]);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -42,32 +42,38 @@ async function openModal(eventId) {
 
       <p class="text-sm"><span class="text-xl">${event.total_participants}</span>人参加 ></p>
     `
-    switch (0) {
-      case 0:
+    switch (event.status) {
+      case 'presence':
         modalHTML += `
-          <div class="text-center mt-6">
-            <!--
-            <p class="text-lg font-bold text-yellow-400">未回答</p>
-            <p class="text-xs text-yellow-400">期限 ${event.deadline}</p>
-            -->
+          <div class="text-center mt-10">
+            <p class="text-xl font-bold text-green-400">参加</p>
           </div>
           <div class="flex mt-5">
-          <button id="participateButton" class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
-          <button id="notParticipateButton" class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="notParticipateEvent(${eventId})">参加しない</button>
+            <button id="participateButton" class="flex-1 bg-blue-500 pointer-events-none py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
+            <button id="notParticipateButton" class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="notParticipateEvent(${eventId})">参加しない</button>
           </div>
         `
         break;
-      case 1:
+      case 'absence':
         modalHTML += `
           <div class="text-center mt-10">
             <p class="text-xl font-bold text-gray-300">不参加</p>
           </div>
+          <div class="flex mt-5">
+            <button id="participateButton" class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
+            <button id="notParticipateButton" class="flex-1 bg-blue-500 pointer-events-none py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="notParticipateEvent(${eventId})">参加しない</button>
+          </div>
         `
         break;
-      case 2:
+      default:
         modalHTML += `
-          <div class="text-center mt-10">
-            <p class="text-xl font-bold text-green-400">参加</p>
+          <div class="text-center mt-6">
+            <p class="text-lg font-bold text-yellow-400">未回答</p>
+            <p class="text-xs text-yellow-400">期限 ${event.deadline}</p>
+          </div>
+          <div class="flex mt-5">
+          <button id="participateButton" class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
+          <button id="notParticipateButton" class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="notParticipateEvent(${eventId})">参加しない</button>
           </div>
         `
         break;
@@ -103,7 +109,7 @@ async function participateEvent(eventId) {
       method: 'POST',
       body: formData
     }).then((res) => {
-      if(res.status !== 200) {
+      if (res.status !== 200) {
         throw new Error("system error");
       }
       return res.text();
@@ -124,7 +130,7 @@ async function notParticipateEvent(eventId) {
       method: 'POST',
       body: formData
     }).then((res) => {
-      if(res.status !== 200) {
+      if (res.status !== 200) {
         throw new Error("system error");
       }
       return res.text();

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -26,6 +26,7 @@ async function openModal(eventId) {
     const url = '/api/getModalInfo.php?eventId=' + eventId
     const res = await fetch(url)
     const event = await res.json()
+    console.log(event.status);
     let modalHTML = `
       <h2 class="text-md font-bold mb-3">${event.name}</h2>
       <p class="text-sm">${event.date}（${event.day_of_week}）</p>
@@ -51,8 +52,8 @@ async function openModal(eventId) {
             -->
           </div>
           <div class="flex mt-5">
-            <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
-            <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="notParticipateEvent(${eventId})">参加しない</button>
+          <button id="participateButton" class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="participateEvent(${eventId})">参加する</button>
+          <button id="notParticipateButton" class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" onclick="notParticipateEvent(${eventId})">参加しない</button>
           </div>
         `
         break;
@@ -89,6 +90,9 @@ function toggleModal() {
   body.classList.toggle('modal-active')
 }
 
+
+const participateButton = document.getElementById("participateButton")
+
 async function participateEvent(eventId) {
   try {
     let formData = new FormData();
@@ -110,7 +114,6 @@ async function participateEvent(eventId) {
     console.log(error)
   }
 }
-
 async function notParticipateEvent(eventId) {
   try {
     let formData = new FormData();


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
- #14 
```
終了条件
参加予定の場合はモーダル画面の参加ボタンを非活性、不参加ボタンを活性
不参加予定の場合はモーダル画面の参加ボタンを活性、不参加ボタンを非活性

前提条件
ログイン機能
```

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->
- 未回答の状態で参加ボタン・不参加ボタンを押せる
- 参加の状態で参加ボタンを押せない
- 参加の状態で不参加ボタンを押せる
- 不参加の状態で不参加ボタンを押せない
- 不参加の状態で参加ボタンを押せる

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
- 画像では活性・非活性伝わらないかと思いますが、選択中の青いボタンは押せないようになっています
<img width="435" alt="スクリーンショット 2022-09-07 19 04 41" src="https://user-images.githubusercontent.com/59753159/188851956-b936688e-ccfa-4470-9372-294e4c590957.png">
<img width="423" alt="スクリーンショット 2022-09-07 19 05 03" src="https://user-images.githubusercontent.com/59753159/188851971-7757bd6e-c993-461b-8d50-5ea5e5f62312.png">
<img width="423" alt="スクリーンショット 2022-09-07 19 05 31" src="https://user-images.githubusercontent.com/59753159/188851978-8113904c-6df8-4510-9a2e-20076593f526.png">

