### PR TITLE
#23 管理画面 Issue3 画面からイベント情報を変更出来るようにする

### DIFF
--- a/src/admin/commitChange.php
+++ b/src/admin/commitChange.php
@@ -1,0 +1,12 @@
+<?php
+
+session_start();
+
+if ($_SESSION['role_id'] !== '2') {
+  header('Location: /auth/login');
+  exit();
+}
+
+require('/var/www/html/dbconnect.php');
+
+

--- a/src/admin/commitChange.php
+++ b/src/admin/commitChange.php
@@ -1,7 +1,5 @@
 <?php
 
-session_start();
-
 if ($_SESSION['role_id'] !== '2') {
   header('Location: /auth/login');
   exit();
@@ -9,4 +7,13 @@ if ($_SESSION['role_id'] !== '2') {
 
 require('/var/www/html/dbconnect.php');
 
+$name = htmlspecialchars($_POST['name']);
+$startAt = htmlspecialchars($_POST['start_at']);
+$endAt = htmlspecialchars($_POST['end_at']);
+$detail = htmlspecialchars($_POST['detail']);
+$id = htmlspecialchars($_POST['id']);
 
+$stmt = $db -> prepare('UPDATE events SET name=?, start_at=?, end_at=?, detail=? WHERE id = ?');
+$stmt -> execute([$name, $startAt, $endAt, $detail, $id]);
+
+echo '<script> alert("イベントを編集しました") </script>';

--- a/src/admin/editEvent.php
+++ b/src/admin/editEvent.php
@@ -1,0 +1,62 @@
+<?php
+
+require('/var/www/html/dbconnect.php');
+
+session_start();
+
+if ($_SESSION['role_id'] !== '2') {
+  header('Location: /auth/login');
+  exit();
+}
+
+if (!isset($_GET['event_id'])){
+  header('Location: events.php');
+  exit();
+}
+
+$eventId = htmlspecialchars($_GET['event_id']);
+
+$stmt = $db -> prepare('SELECT * FROM events WHERE id = ?');
+$stmt -> execute([$eventId]);
+$event = $stmt -> fetch();
+var_dump($event);
+?>
+
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+  <title>Document</title>
+</head>
+<body>
+<header class="h-16">
+    <div class="flex justify-between items-center w-full h-full mx-auto pl-2 pr-5">
+      <div class="h-full">
+        <img src="/img/header-logo.png" alt="" class="h-full">
+      </div>
+      <div>
+        <a href="events.php" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">戻る</a>
+      </div>
+    </div>
+  </header>
+  <main class="bg-gray-100 h-screen">
+    <div class="w-full mx-auto py-10 px-5">
+      <h2 class="text-md font-bold mb-5">イベントの編集</h2>
+      <form action="commitChange.php" method="POST">
+        <p>イベント名</p>
+        <input name="name" type="text" placeholder="<?= $event['name'] ?>" value="<?= $event['name'] ?>" class="w-full p-4 text-sm mb-3">
+        <p>開始日時</p>
+        <input name="start_at" type="text" placeholder="<?= $event['start_at'] ?>" value="<?= $event['start_at'] ?>" class="w-full p-4 text-sm mb-3">
+        <p>終了日時</p>
+        <input name="end_at" type="text" placeholder="<?= $event['end_at'] ?>" value="<?= $event['end_at'] ?>" class="w-full p-4 text-sm mb-3">
+        <p>イベントの内容</p>
+        <textarea name="detail" id="" cols="30" rows="10"><?= $event['detail'] ?></textarea>
+        <input type="submit" value="確定" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
+      </form>
+    </div>
+  </main>
+</body>
+</html>

--- a/src/admin/editEvent.php
+++ b/src/admin/editEvent.php
@@ -9,6 +9,10 @@ if ($_SESSION['role_id'] !== '2') {
   exit();
 }
 
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  require ('commitChange.php');
+}
+
 if (!isset($_GET['event_id'])){
   header('Location: events.php');
   exit();
@@ -19,7 +23,6 @@ $eventId = htmlspecialchars($_GET['event_id']);
 $stmt = $db -> prepare('SELECT * FROM events WHERE id = ?');
 $stmt -> execute([$eventId]);
 $event = $stmt -> fetch();
-var_dump($event);
 ?>
 
 <!DOCTYPE html>
@@ -45,7 +48,7 @@ var_dump($event);
   <main class="bg-gray-100 h-screen">
     <div class="w-full mx-auto py-10 px-5">
       <h2 class="text-md font-bold mb-5">イベントの編集</h2>
-      <form action="commitChange.php" method="POST">
+      <form action="" method="POST">
         <p>イベント名</p>
         <input name="name" type="text" placeholder="<?= $event['name'] ?>" value="<?= $event['name'] ?>" class="w-full p-4 text-sm mb-3">
         <p>開始日時</p>
@@ -54,6 +57,7 @@ var_dump($event);
         <input name="end_at" type="text" placeholder="<?= $event['end_at'] ?>" value="<?= $event['end_at'] ?>" class="w-full p-4 text-sm mb-3">
         <p>イベントの内容</p>
         <textarea name="detail" id="" cols="30" rows="10"><?= $event['detail'] ?></textarea>
+        <input type="hidden" name="id" value="<?= $event['id'] ?>">
         <input type="submit" value="確定" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
       </form>
     </div>

--- a/src/admin/events.php
+++ b/src/admin/events.php
@@ -1,0 +1,182 @@
+<?php
+
+require('/var/www/html/dbconnect.php');
+
+session_start();
+
+if ($_SESSION['role_id'] !== '2') {
+  header('Location: /auth/login');
+  exit();
+}
+
+$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(status = "presence" or null) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id ORDER BY events.start_at ASC');
+$events = $stmt->fetchAll();
+
+function get_day_of_week($w)
+{
+  $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
+  return $day_of_week_list["$w"];
+}
+?>
+
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+  <title>admin | schedule</title>
+</head>
+
+<body>
+  <header class="h-16">
+    <div class="flex justify-between items-center w-full h-full mx-auto pl-2 pr-5">
+      <div class="h-full">
+        <img src="../img/header-logo.png" alt="" class="h-full">
+      </div>
+      <!--
+      <div>
+        <a href="/auth/login" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ログイン</a>
+      </div>
+      -->
+      <div>
+        <a href="index.php" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">top</a>
+      </div>
+    </div>
+  </header>
+
+  <main class="bg-gray-100">
+    <div class="w-full mx-auto p-5">
+      <!--
+      <div id="filter" class="mb-8">
+        <h2 class="text-sm font-bold mb-3">フィルター</h2>
+        <div class="flex">
+          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-blue-600 text-white">全て</a>
+          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">参加</a>
+          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
+          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a>
+        </div>
+      </div>
+      -->
+      <div id="events-list">
+        <div class="flex justify-between items-center mb-3">
+          <h2 class="text-sm font-bold">管理画面 イベント一覧</h2>
+        </div>
+
+        <!-- 各イベントボックス（一覧）見た目 -->
+        <?php
+        $futureEvents = [];
+        foreach ($events as $event) {
+          $start_date = strtotime($event['start_at']);
+          if ($start_date < strtotime(date('Y-m-d H:i'))) {
+            continue;
+          }
+          array_push($futureEvents, $event);
+        }
+
+        ?>
+
+        <!-- 以下ページネーション -->
+        <?php
+        define('MAX', 10); //1ページの記事の表示数
+
+        $events_num = count($futureEvents); //トータルデータ件数
+        $max_page = ceil($events_num / MAX); //トータルページ数
+
+
+        if (!isset($_GET['page'])) { // $_GET['page_id'] はURLに渡された現在のページ数
+          $page = 1; // 設定されてない場合は1ページ目にする
+        } else {
+          $page = (int)htmlspecialchars($_GET['page']);
+        }
+        // 前のページ番号は1と比較して大きい方を使う
+        $prev = max($page - 1, 1);
+
+        // 次のページ番号は最大ページ数と比較して小さい方を使う
+        $next = min($page + 1, $max_page);
+
+        function paging($max_page, $page = 1)
+        {
+          $prev = max($page - 1, 1); // 前のページ番号
+          $next = min($page + 1, $max_page); // 次のページ番号
+
+          if ($page != 1) { // 最初のページ以外で「前へ」を表示
+            print '<a href="?page=' . $prev . '">&laquo; 前へ</a>';
+          }
+          if ($page < $max_page) { // 最後のページ以外で「次へ」を表示
+            print '<a href="?page=' . $next . '">次へ &raquo;</a>';
+          }
+        }
+
+        // 1ページに10個だけ表示させる
+        $startNo = ($page - 1) * MAX;
+
+        $disp_data = array_slice($futureEvents, $startNo, MAX, true);
+
+        foreach ($disp_data as $event) :
+          $start_date = strtotime($event['start_at']);
+          $end_date = strtotime($event['end_at']);
+          $day_of_week = get_day_of_week(date("w", $start_date));
+        ?>
+
+          <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
+            <a href="<?= 'editEvent.php?event_id=' . $event['id'] ?>">
+              <div>
+                <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
+                <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
+                <p class="text-xs text-gray-600">
+                  <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
+                </p>
+              </div>
+              <div class="flex flex-col justify-between text-right">
+                <div>
+                  <?php if ($event['id'] % 3 === 1) : ?>
+                    <!--
+                    <p class="text-sm font-bold text-yellow-400">未回答</p>
+                    <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $end_date)); ?></p>
+                    -->
+                  <?php elseif ($event['id'] % 3 === 2) : ?>
+                    <!--
+                    <p class="text-sm font-bold text-gray-300">不参加</p>
+                    -->
+                  <?php else : ?>
+                    <!--
+                    <p class="text-sm font-bold text-green-400">参加</p>
+                    -->
+                  <?php endif; ?>
+                </div>
+                <p class="text-sm"><span class="text-xl"><?php echo $event['total_participants']; ?></span>人参加</p>
+              </div>
+            </a>
+          </div>
+        <?php endforeach;
+
+        paging($max_page, $_GET['page']);
+        ?>
+      </div>
+    </div>
+  </main>
+
+  <div class="modal opacity-0 pointer-events-none fixed w-full h-full top-0 left-0 flex items-center justify-center">
+    <div class="modal-overlay absolute w-full h-full bg-black opacity-80"></div>
+
+    <div class="modal-container absolute bottom-0 bg-white w-screen h-4/5 rounded-t-3xl shadow-lg z-50">
+      <div class="modal-content text-left py-6 pl-10 pr-6">
+        <div class="z-50 text-right mb-5">
+          <svg class="modal-close cursor-pointer inline bg-gray-100 p-1 rounded-full" xmlns="http://www.w3.org/2000/svg" width="34" height="34" viewBox="0 0 18 18">
+            <path d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"></path>
+          </svg>
+        </div>
+
+        <!-- <div id="modalInner"></div> -->
+
+      </div>
+    </div>
+  </div>
+
+  <!-- <script src="/js/main.js"></script> -->
+</body>
+
+</html>

--- a/src/admin/index.php
+++ b/src/admin/index.php
@@ -20,10 +20,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     unset($_POST['start_at']);
     unset($_POST['end_at']);
     unset($_POST['detail']);
-    $stmt = $db -> prepare(
-    'INSERT INTO events SET name=?, start_at=?, end_at=?, detail=?');
-    $stmt -> execute([$eventName, $startAt, $endAt, $eventDetail]);
-    echo('<script>alert("イベントが作成されました")</script>');
+    $stmt = $db->prepare(
+      'INSERT INTO events SET name=?, start_at=?, end_at=?, detail=?'
+    );
+    $stmt->execute([$eventName, $startAt, $endAt, $eventDetail]);
+    echo ('<script>alert("イベントが作成されました")</script>');
     // $stmt = $db -> prepare('SELECT detail FROM events WHERE name = ?');
     // $stmt -> execute([$eventName]);
     // $result = $stmt -> fetch();
@@ -45,7 +46,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
-  <title>Document</title>
+  <title>admin|schedule|posse</title>
 </head>
 
 <body>
@@ -54,11 +55,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       <div class="h-full">
         <img src="/img/header-logo.png" alt="" class="h-full">
       </div>
+      <div>
+        <a href="/auth/logout" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ログアウト</a>
+      </div>
     </div>
   </header>
   <main class="bg-gray-100 h-screen">
     <div class="w-full mx-auto py-10 px-5">
-      <h2 class="text-md font-bold mb-5">イベント作成</h2>
+      <h2 class="text-md font-bold mb-5">管理画面 topページ <br> イベント作成</h2>
       <?php if (isset($errorMessage)) : ?>
         <p class="text-red-500 font-bold mb-3"><?= $errorMessage ?></p>
       <?php endif; ?>
@@ -72,6 +76,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <textarea name="detail" placeholder="イベントの内容" class="w-full p-4 text-sm mb-3"></textarea>
         <input type="submit" value="作成" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
       </form>
+      <br>
+      <h2 class="text-md font-bold mb-5"><a href='events.php'>イベント一覧へ</a></h2>
     </div>
   </main>
 </body>

--- a/src/index.php
+++ b/src/index.php
@@ -25,7 +25,7 @@ function get_day_of_week($w)
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+c
   <title>Schedule | POSSE</title>
 </head>
 

--- a/src/index.php
+++ b/src/index.php
@@ -8,7 +8,7 @@ if (!isset($_SESSION['user_id'])) {
   exit();
 }
 
-$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(status = "presence" or null) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id');
+$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(status = "presence" or null) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id ORDER BY start_at');
 $events = $stmt->fetchAll();
 
 function get_day_of_week($w)
@@ -25,7 +25,7 @@ function get_day_of_week($w)
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-c
+  <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
   <title>Schedule | POSSE</title>
 </head>
 


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
- #23 
```
終了条件
管理画面から登録済みのイベント一覧が確認できること、
また、イベントを選択してイベント名、開催日時、イベント内容を変更できること
管理画面には管理者のみログイン出来る
```
## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->
管理者アカウントでログイン後、実際に編集して、管理者画面およびユーザー画面のイベント一覧で変更を確認しました。

ログイン画面で管理者アカウントのメールアドレス、パスワードでログインすると専用の画面に移動することを確認しました。
ログインしていないときやユーザーのアカウントでログインしているとき、ログインページに飛ぶことを確認しました。

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
管理画面から登録済みのイベント一覧を確認
<img width="430" alt="スクリーンショット 2022-09-08 23 48 39" src="https://user-images.githubusercontent.com/59753159/189154881-a545bf24-1356-4563-b878-9a578caa5e3a.png">


イベントを選択してイベント名、開催日時、イベント内容を変更
<img width="431" alt="スクリーンショット 2022-09-08 23 49 04" src="https://user-images.githubusercontent.com/59753159/189154972-e33ef1d4-4196-4c13-8037-ae6bd2c6c37b.png">

<img width="429" alt="スクリーンショット 2022-09-08 23 50 15" src="https://user-images.githubusercontent.com/59753159/189155064-9d017194-5857-45ef-be6a-4cf206d2af90.png">


変更されていることを確認。
<img width="434" alt="スクリーンショット 2022-09-08 23 50 56" src="https://user-images.githubusercontent.com/59753159/189155133-9c1db255-cee7-456c-8d12-39d935503a11.png">
<img width="427" alt="スクリーンショット 2022-09-08 23 51 25" src="https://user-images.githubusercontent.com/59753159/189155142-8feeeb2b-4df9-46b4-b273-bfd872cb3626.png">
<img width="1432" alt="スクリーンショット 2022-09-08 23 53 13" src="https://user-images.githubusercontent.com/59753159/189155148-64f2a703-593d-4c72-8d50-43c234271e8b.png">
