### PR TITLE
#15 イベント参加管理 Issue4 トップページに自身の回答状況を表示する

### DIFF
--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -25,10 +25,6 @@ if (isset($_GET['eventId'])) {
       $eventMessage = date("Y年m月d日", $start_date) . '（' . get_day_of_week(date("w", $start_date)) . '） ' . date("H:i", $start_date) . '~' . date("H:i", $end_date) . 'に' . $event['name'] . 'を開催します。<br>ぜひ参加してください。';
     }
 
-    if ($event['id'] % 3 === 1) $status = 0;
-    elseif ($event['id'] % 3 === 2) $status = 1;
-    else $status = 2;
-
     $array = [
       'id' => $event['id'],
       'name' => $event['name'],

--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -28,14 +28,14 @@ if (isset($_GET['eventId'])) {
     $array = [
       'id' => $event['id'],
       'name' => $event['name'],
-      'date' => date("Y年m月d日", $start_date),
+      'date' => date("Y年n月j日", $start_date),
       'day_of_week' => get_day_of_week(date("w", $start_date)),
       'start_at' => date("H:i", $start_date),
       'end_at' => date("H:i", $end_date),
       'total_participants' => $event['total_participants'],
       'message' => $eventMessage,
       'status' => $eventAttendance['status'],
-      'deadline' => date("m月d日", strtotime('-3 day', $end_date)),
+      'deadline' => date("n月j日", strtotime('-3 day', $end_date)),
     ];
 
     echo json_encode($array, JSON_UNESCAPED_UNICODE);

--- a/src/index.php
+++ b/src/index.php
@@ -129,19 +129,19 @@ function get_day_of_week($w)
             </div>
             <div class="flex flex-col justify-between text-right">
               <div>
-                <?php if ($event['id'] % 3 === 1) : ?>
-                  <!--
-                  <p class="text-sm font-bold text-yellow-400">未回答</p>
-                  <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $end_date)); ?></p>
-                  -->
-                <?php elseif ($event['id'] % 3 === 2) : ?>
-                  <!--
-                  <p class="text-sm font-bold text-gray-300">不参加</p>
-                  -->
-                <?php else : ?>
-                  <!--
+                <?php if ($event_attendance['status'] === 'presence'): ?>
+                  
                   <p class="text-sm font-bold text-green-400">参加</p>
-                  -->
+                
+                <?php elseif ($event_attendance['status'] === 'absence') : ?>
+                  
+                  <p class="text-sm font-bold text-gray-300">不参加</p>
+                
+                <?php else : ?>
+                  
+                  <p class="text-sm font-bold text-yellow-400">未回答</p>
+                  <!-- <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $end_date)); ?></p> -->
+                
                 <?php endif; ?>
               </div>
               <p class="text-sm"><span class="text-xl"><?php echo $event['total_participants']; ?></span>人参加</p>

--- a/src/index.php
+++ b/src/index.php
@@ -155,7 +155,7 @@ function get_day_of_week($w)
                 <?php elseif ($status === 'not_submitted') : ?>
 
                   <p class="text-sm font-bold text-yellow-400">未回答</p>
-                  <p class="text-xs text-yellow-400">期限 <?php echo date("n月j日", strtotime('-3 day', $end_date)); ?></p>
+                  <p class="text-xs text-yellow-400">期限 <?php echo date("n月j日", strtotime('-3 day', $start_date)); ?></p>
 
                 <?php endif; ?>
               </div>


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
- #15 

```
終了条件
トップページの対象イベントに回答状況を表示する
まだ回答していない場合は未回答
参加の場合は参加
不参加の場合は不参加

備考
未回答の場合に期限表示を実装するとより良い（+1ビジネスポイント）
```

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->
- 参加と回答したものは参加、不参加と回答したものは不参加、回答していないものは未回答と一覧で表示されることを確認
- 未回答の場合、期限が表示されることを確認

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
<img width="425" alt="スクリーンショット 2022-09-08 0 32 36" src="https://user-images.githubusercontent.com/59753159/188918979-dc5cc2b8-421a-4886-8e8d-772abf4ce880.png">

