### PR TITLE
[fix] 次へ、前へのバグ修正

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -186,7 +186,7 @@ function get_day_of_week($w)
           </div>
         <?php endforeach;
 
-        paging($max_page, $_GET['page']);
+        paging($max_page, $page);
         ?>
       </div>
     </div>


### PR DESCRIPTION
クエリがないとき、絞り込み後などでもページネーションの辻褄を合わせる