### PR TITLE
#25 未回答管理 Issue2 イベントの3日前にメールで通知する 通知する先はユーザレコードの人すべて

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -65,9 +65,9 @@ INSERT INTO users SET name='岩村潤', email='jun@email.com', password='$2y$10$
 
 INSERT INTO events SET name='HarborSもくもく会vol.23', start_at='2022/08/01 12:00', end_at='2022/08/01 16:00';
 INSERT INTO events SET name='Swift勉強会@HarborS #127', start_at='2022/08/02 11:00', end_at='2022/08/02 14:00';
-INSERT INTO events SET name='みんなでRustを楽しもうの会!!', start_at='2022/09/010 10:00', end_at='2022/09/10 13:00';
-INSERT INTO events SET name='みんなで夏を感じる納涼祭り@多摩川', start_at='2022/09/15 16:00', end_at='2022/09/15 21:00';
-INSERT INTO events SET name='再び！Tower to Tower', start_at='2022/09/20 11:00', end_at='2022/09/20 18:00';
+INSERT INTO events SET name='みんなでRustを楽しもうの会!!', start_at='2022/09/10 10:00', end_at='2022/09/10 13:00', detail='みんな大好きRust言語を使って楽しいアプリを作りましょう！事前準備はなにもいりません。HarborS利用者は無料、一般500円です。';
+INSERT INTO events SET name='みんなで夏を感じる納涼祭り@多摩川', start_at='2022/09/11 16:00', end_at='2022/09/11 21:00', detail='みんなで水遊びしたり花火したりして夏を感じましょう！';
+INSERT INTO events SET name='再び！Tower to Tower', start_at='2022/09/12 11:00', end_at='2022/09/12 18:00', detail='あの伝説のイベントが再び！履き慣れた靴でお越しください。';
 INSERT INTO events SET name='小谷さん集中講義~Nginx編~', start_at='2022/09/23 20:00', end_at='2022/09/23 22:00';
 INSERT INTO events SET name='すーさんとフロント勉強会', start_at='2022/09/25 21:00', end_at='2022/09/25 23:00';
 INSERT INTO events SET name='表参道カフェ巡りvol.3', start_at='2022/09/28 12:00', end_at='2022/09/28 15:00';
@@ -83,7 +83,7 @@ INSERT INTO events SET name='3期生と競う！JavaScriptゲーム制作大会'
 INSERT INTO events SET name='JOBerと嗜むモダンJavaScript', start_at='2022/10/30 18:00', end_at='2022/10/30 22:00';
 INSERT INTO events SET name='初心者向けCSSスタイリング講座', start_at='2022/11/05 18:00', end_at='2022/11/05 22:00';
 INSERT INTO events SET name='南青山定例ゴミ拾いもくもく会(11月)', start_at='2022/11/07 14:00', end_at='2022/11/07 16:00';
-INSERT INTO events SET name='arborSもくもく会vol.25', start_at='2022/11/10 13:00', end_at='2022/11/10 15:00';
+INSERT INTO events SET name='HarborSもくもく会vol.25', start_at='2022/11/10 13:00', end_at='2022/11/10 15:00';
 INSERT INTO events SET name='JavaScript勉強会#1534', start_at='2022/11/19 12:00', end_at='2022/11/19 17:00';
 INSERT INTO events SET name='Swift勉強会@HarborS #128', start_at='2022/11/23 15:00', end_at='2022/11/23 19:00';
 INSERT INTO events SET name='Winter Hackathon 2022', start_at='2022/12/03 12:00', end_at='2022/12/06 20:00';

--- a/src/mail/sendMailToEveryoneThreeDaysAgo.php
+++ b/src/mail/sendMailToEveryoneThreeDaysAgo.php
@@ -1,0 +1,53 @@
+<?php
+
+require('/var/www/html/dbconnect.php');
+
+// 全ユーザーを取得
+$stmt = $db->query('SELECT * FROM users');
+$users = $stmt->fetchAll();
+
+// 3日後のイベントを取得
+$eventDate = date('Y-m-d', strtotime('+3 day'));
+$stmt = $db->prepare(
+  'SELECT
+    id,
+    name,
+    events.detail,
+    TIME_FORMAT(start_at, "%H:%i") start_at,
+    TIME_FORMAT(end_at, "%H:%i") end_at
+  FROM
+    events
+  WHERE DATE_FORMAT(start_at, "%Y-%m-%d") = ?'
+);
+$stmt->execute([$eventDate]);
+$events = $stmt->fetchAll();
+
+// メール送信
+mb_language('ja');
+mb_internal_encoding('UTF-8');
+foreach ($events as $event) {
+  foreach ($users as $user) {
+    $to = $user['email'];
+    $subject = $event['name'] . 'の参加回答期限が迫っています';
+    $name = $user['name'];
+    $eventName = $event['name'];
+    $detail = $event['detail'];
+    $startAt = $event['start_at'];
+    $endAt = $event['end_at'];
+    $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
+    $body = <<<EOT
+    {$name}さん
+
+    以下のイベントの参加回答期限は今日の23:59までです。期限までに参加可否を回答してください。
+
+    ----------------------------------------------
+    イベント名: {$eventName}
+    開催日時: {$startAt} ~ {$endAt}
+    詳細: {$detail}
+    ----------------------------------------------
+    EOT;
+    mb_send_mail($to, $subject, $body, $headers);
+  }
+}
+
+echo "メールを送信しました\n";


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
- #25 
```
終了条件
バッチを実行すると処理日がイベントの3日前の場合メールを送付する
メールの宛先はユーザレコードの人全て
メールにはイベント名、内容、開催日時、回答を促す内容を記載する

備考
プログラムはバッチ実装
バッチのスケジューリングは不要で手動実行想定

■バッチについて
ターミナルで以下コマンドで実行可能なこと
php hogehoge.php
※ファイル名は任意です
```


## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->
- `php mail/sendRequestMailToEveryone.php`を実行すると、3日後に開催されるイベントの参加可否を回答するよう促すメールが送信されることを確認

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
<img width="874" alt="スクリーンショット 2022-09-08 23 56 53" src="https://user-images.githubusercontent.com/59753159/189155794-c9bece13-8191-4e0b-9c2a-f78319d2b947.png">

<img width="1800" alt="スクリーンショット 2022-09-08 23 58 44" src="https://user-images.githubusercontent.com/59753159/189156203-25290374-cd55-4e49-b89b-c0a4ae97ae1f.png">

<img width="1800" alt="スクリーンショット 2022-09-08 23 59 18" src="https://user-images.githubusercontent.com/59753159/189156373-2dd0abd1-21ec-459e-8c36-60d05984a2da.png">

