### PR TITLE
#26 未回答管理 Issue3 イベントの3日前にメールで通知する 通知する先は未回答となっている人のみ

### DIFF
--- a/src/mail/sendMailToNotSubmittedUsersThreeDaysAgo.php
+++ b/src/mail/sendMailToNotSubmittedUsersThreeDaysAgo.php
@@ -1,0 +1,55 @@
+<?php
+
+require('/var/www/html/dbconnect.php');
+
+// 3日後のイベントを取得
+$eventDate = date('Y-m-d', strtotime('+3 day'));
+$stmt = $db->prepare(
+    'SELECT
+    id,
+    name,
+    events.detail,
+    TIME_FORMAT(start_at, "%H:%i") start_at,
+    TIME_FORMAT(end_at, "%H:%i") end_at
+  FROM
+    events
+  WHERE DATE_FORMAT(start_at, "%Y-%m-%d") = ?'
+);
+$stmt->execute([$eventDate]);
+$events = $stmt->fetchAll();
+
+// メール送信
+mb_language('ja');
+mb_internal_encoding('UTF-8');
+foreach ($events as $event) {
+
+    // 未提出のユーザーを取得
+    $stmt = $db->prepare('SELECT * FROM event_attendance LEFT JOIN users ON event_attendance.user_id = users.id WHERE event_id = ? AND status = "not_submitted"');
+    $stmt->execute([$event['id']]);
+    $notSubmittedUsers = $stmt->fetchAll();
+
+    foreach ($notSubmittedUsers as $user) {
+        $to = $user['email'];
+        $subject = $event['name'] . 'の参加回答期限が迫っています';
+        $name = $user['name'];
+        $eventName = $event['name'];
+        $detail = $event['detail'];
+        $startAt = $event['start_at'];
+        $endAt = $event['end_at'];
+        $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
+        $body = <<<EOT
+    {$name}さん
+
+    以下のイベントの参加回答期限は今日の23:59までです。期限までに参加可否を回答してください。
+
+    ----------------------------------------------
+    イベント名: {$eventName}
+    開催日時: {$startAt} ~ {$endAt}
+    詳細: {$detail}
+    ----------------------------------------------
+    EOT;
+        mb_send_mail($to, $subject, $body, $headers);
+    }
+}
+
+echo "メールを送信しました\n";


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
- #26 
```
終了条件
バッチを実行すると処理日がイベントの3日前の場合メールを送付する
メールの宛先は未回答としている人のみ
メールにはイベント名、内容、開催日時、回答を促す内容を記載する
```

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->
- `php mail/sendMailToNotSubmittedUsersThreeDaysAgo.php`を実行すると、該当イベントの参加可否を回答していないユーザーのメールアドレスに回答を促すメールが送信されることを確認しました

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->

- 参考までに該当イベントの参加ステータス

<img width="1432" alt="スクリーンショット 2022-09-08 2 00 38" src="https://user-images.githubusercontent.com/59753159/188937877-72f2132d-c089-46a9-a402-9ec6d62bc804.png">

<img width="618" alt="スクリーンショット 2022-09-08 2 07 51" src="https://user-images.githubusercontent.com/59753159/188938375-d94eb47d-5d18-4038-b2cc-c537ade24f71.png">
<img width="1500" alt="スクリーンショット 2022-09-08 2 01 04" src="https://user-images.githubusercontent.com/59753159/188937882-9f845653-71bc-458b-8f9b-a486eddc87b1.png">
<img width="1497" alt="スクリーンショット 2022-09-08 2 01 25" src="https://user-images.githubusercontent.com/59753159/188937883-e43b87f3-26c8-4cf8-873d-e44f9b386333.png">
